### PR TITLE
Bump upper version limit of dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,11 @@
 # This file can be used to install module dependencies for unit testing
 # See https://github.com/puppetlabs/puppetlabs_spec_helper#using-fixtures for details
-
 ---
 fixtures:
-  repositories:
+  forge_modules:
     stdlib:
-      repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.13.1
+      repo: "puppetlabs/stdlib"
     archive:
-      repo: https://github.com/voxpupuli/puppet-archive.git
-      ref: v1.0.0
+      repo: "puppet/archive"
   symlinks:
     golang: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <8.0.0"
+      "version_requirement": ">= 4.13.1 <9.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 <6.0.0"
+      "version_requirement": ">= 1.0.0 <7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Bumped the upper version limits of stdtlib and archive to their latest
release and removed rspec-puppet version fixtures for the two modules.
The rspec-puppet run was successful.
